### PR TITLE
Add config.yml to point to discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 blank_issues_enabled: true
 contact_links:
   - name: Ask a Question

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/nv-morpheus/Morpheus/security/policy
+    about: Please review our [security policy](https://github.com/nv-morpheus/Morpheus/security/policy) for more details.
+  - name: Ask a Question
+    url: https://github.com/nv-morpheus/Morpheus-Experimental/Discussions
+    about: Please ask any questions here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Report a security vulnerability
-    url: https://github.com/nv-morpheus/Morpheus/security/policy
-    about: Please review our [security policy](https://github.com/nv-morpheus/Morpheus/security/policy) for more details.
   - name: Ask a Question
-    url: https://github.com/nv-morpheus/Morpheus-Experimental/Discussions
+    url: https://github.com/nv-morpheus/morpheus-experimental/discussions
     about: Please ask any questions here.


### PR DESCRIPTION
Question issues are a bit unweildy to manage in the new projects system (what release do they fit into? When are they done?) but thankfully GitHub has discussions, made just for them.

This PR adds a link to the discussions tab when they open a new issue. This way we don't have people opening QST issues and instead use the correct location.

**Don't merge this until Discussions are enabled in the repo.**