### PR TITLE
Create a PR Template and Consolidate GH Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -16,5 +16,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Ask a Question
-    url: https://github.com/nv-morpheus/morpheus-experimental/discussions
+    url: https://github.com/nv-morpheus/morpheus/discussions
     about: Please ask any questions here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Description
+<!-- Provide a standalone description of changes in this PR. -->
+<!-- Reference any issues closed by this PR with "closes #1234". -->
+<!-- Note: The pull request title will be included in the CHANGELOG. -->
+
+## Checklist
+- [ ] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
+- [ ] New or existing tests cover these changes.
+- [ ] The documentation is up to date with these changes.


### PR DESCRIPTION
This PR does two things:
- Creates a PR template for future PRs
- Changes the `ask a question` link to point to the main Morpheus discussions page
   - After merge, I'll be disabling Discussions here, and instead all Discussion will happen inside the main page
   - This will make it easier for the team to keep on top of Discussions that come in