### PR TITLE
Forward-merge branch-23.07 to branch-23.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# morpheus-experimental 23.07.00 (18 Jul 2023)
+
+## 📖 Documentation
+
+- Modelcard++ OT (ICS) &amp; DGA ([#53](https://github.com/nv-morpheus/morpheus-experimental/pull/53)) [@gbatmaz](https://github.com/gbatmaz)
+- Modelcard++ (IDS, Log sequence &amp; anomalous-auth) ([#52](https://github.com/nv-morpheus/morpheus-experimental/pull/52)) [@tzemicheal](https://github.com/tzemicheal)
+- Added SRG model and updated MC and MC++ ([#51](https://github.com/nv-morpheus/morpheus-experimental/pull/51)) [@shawn-davis](https://github.com/shawn-davis)
+- Fix IDS title in readme file ([#47](https://github.com/nv-morpheus/morpheus-experimental/pull/47)) [@tzemicheal](https://github.com/tzemicheal)
+
+## 🚀 New Features
+
+- Migrate CLX DGA Detection ([#46](https://github.com/nv-morpheus/morpheus-experimental/pull/46)) [@efajardo-nv](https://github.com/efajardo-nv)
+- Create label-external-issues.yml ([#45](https://github.com/nv-morpheus/morpheus-experimental/pull/45)) [@jarmak-nv](https://github.com/jarmak-nv)
+- IDS-LODA clx migration ([#38](https://github.com/nv-morpheus/morpheus-experimental/pull/38)) [@tzemicheal](https://github.com/tzemicheal)
+
+## 🛠️ Improvements
+
+- Adding a `update-version.sh` script to help with releases ([#54](https://github.com/nv-morpheus/morpheus-experimental/pull/54)) [@mdemoret-nv](https://github.com/mdemoret-nv)
+- Update versions in container to match Morpheus ([#49](https://github.com/nv-morpheus/morpheus-experimental/pull/49)) [@efajardo-nv](https://github.com/efajardo-nv)
+- Create a PR Template and Consolidate GH Discussions ([#42](https://github.com/nv-morpheus/morpheus-experimental/pull/42)) [@jarmak-nv](https://github.com/jarmak-nv)
+- Use ARC V2 self-hosted runners for CPU jobs ([#39](https://github.com/nv-morpheus/morpheus-experimental/pull/39)) [@jjacobelli](https://github.com/jjacobelli)
+
 # morpheus-experimental 23.03.00 (29 Mar 2023)
 
 ## 🚀 New Features


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.07` that creates a PR to keep `branch-23.11` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.